### PR TITLE
Warp update same line prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,16 @@ flowchart TD
 ## Colorization options / settings
 | Option                  | Description                              | Default value    | Type    |
 |-------------------------|------------------------------------------|------------------|---------|
-| BB_PROMPT_DIR           | The working directory                    | `"#6c71c4"` ![#6c71c4](https://via.placeholder.com/15/6c71c4/6c71c4.png) | string  |
-| BB_PROMPT_GIT           | The shown VCS in use (`git:()`)          | `"#586e75"` ![#586e75](https://via.placeholder.com/15/586e75/586e75.png) | string  |
-| BB_PROMPT_BRANCH        | The git branch name                      | `"#dc322f"` ![#dc322f](https://via.placeholder.com/15/dc322f/dc322f.png) | string  |
-| BB_PROMPT_ACTION        | The git actions rebase/merge             | `"#b58900"` ![#b58900](https://via.placeholder.com/15/b58900/b58900.png) | string  |
-| BB_PROMPT_AHEAD_BEHIND  | The ahead and behind arrows + counters   | `"#2aa198"` ![#2aa198](https://via.placeholder.com/15/2aa198/2aa198.png) | string  |
-| BB_PROMPT_TAG           | The git tag                              | `"#93a1a1"` ![#93a1a1](https://via.placeholder.com/15/93a1a1/93a1a1.png) | string  |
-| BB_PROMPT_COUNT         | Changed file count on branch             | `"#93a1a1"` ![#93a1a1](https://via.placeholder.com/15/93a1a1/93a1a1.png) | string  |
+| BB_PROMPT_DIR           | The working directory                    | `"13"` ![#6c71c4](https://via.placeholder.com/15/6c71c4/6c71c4.png) | string  |
+| BB_PROMPT_GIT           | The shown VCS in use (`git:()`)          | `"10"` ![#586e75](https://via.placeholder.com/15/586e75/586e75.png) | string  |
+| BB_PROMPT_BRANCH        | The git branch name                      | `"1"`  ![#dc322f](https://via.placeholder.com/15/dc322f/dc322f.png) | string  |
+| BB_PROMPT_ACTION        | The git actions rebase/merge             | `"3"`  ![#b58900](https://via.placeholder.com/15/b58900/b58900.png) | string  |
+| BB_PROMPT_AHEAD_BEHIND  | The ahead and behind arrows + counters   | `"4"`  ![#2aa198](https://via.placeholder.com/15/2aa198/2aa198.png) | string  |
+| BB_PROMPT_COUNT         | Changed file count on branch             | `"14"` ![#93a1a1](https://via.placeholder.com/15/93a1a1/93a1a1.png) | string  |
 |                         |                                          |                  |         |
-| BB_PROMPT_SHOW_TAG      | Turn show tag option on or off           | `false`          | bool    |
+| BB_PROMPT_TAG           | The git tag color (If not empty the git tag is active) | `""`  | string  |
+| BB_PROMPT_CLOCK         | The clock (If not empty the clock is active)           | `""`  | string  |
+|                         |                                          |                  |         |
 | BB_PROMPT_PROJECTS_PATH | The path of the project folder           | `"${HOME}/code"` | string  |
 | BB_PROMPT_PROJECTS      | Turn the project folder option on or off | `true`           | bool    |
 | BB_PROMPT_SIGN          | Set the character of the prompt          | `"%"`            | string  |
@@ -113,7 +114,6 @@ export BB_PROMPT_GIT="#EEEEEE"
 export BB_PROMPT_TAG="blue"
 export BB_PROMPT_PROJECTS_PATH="${HOME}/my/projects/path"
 export BB_PROMPT_PROJECTS=false
-export BB_PROMPT_SHOW_TAG=true
 export BB_PROMPT_SIGN="$"
 
 # only load prompt if the `bb.zsh` file exists
@@ -137,8 +137,8 @@ source $HOME/.config/zsh/backbone-zsh-prompt/bb.zsh
 - [x] option to set prompt sign for e.g. iterm
 - [x] use ansi escape codes for terminal colors when not in warp terminal
 - [x] fix git-tag issue (when git-tag is set but no git tag is present the space between the branchname and staged/unstaged symbol is not being displayed)
+- [x] custom colorization of prompt sign success/failure
 - [ ] easier installation
-- [ ] custom colorization of prompt sign success/failure
 - [ ] make it faster!?
 - [ ] option for DEBUG!?
 

--- a/bb.zsh
+++ b/bb.zsh
@@ -25,6 +25,7 @@
 ! [ -v BB_PROMPT_PROJECTS ] && BB_PROMPT_PROJECTS=true
 ! [ -v BB_PROMPT_SHOW_TAG ] && BB_PROMPT_SHOW_TAG=false
 ! [ -v BB_PROMPT_SIGN ] && BB_PROMPT_SIGN="%%"
+! [ -v BB_PROMPT_CLOCK ] && BB_PROMPT_CLOCK=""
 
 ## vim:ft=zsh
 
@@ -104,6 +105,11 @@ prompt_precmd() {
         PS1=$'\n''%B%F{${BB_PROMPT_DIR}}%~%f'$'\n''%(?.%F{2}${BB_PROMPT_SIGN}.%F{9}${BB_PROMPT_SIGN})%f%b '
     else
         PS1=$'\n''%B%F{${BB_PROMPT_DIR}}%~%f ${vcs_info_msg_0_}'$'\n''%(?.%F{2}${BB_PROMPT_SIGN}.%F{9}${BB_PROMPT_SIGN})%f%b '
+    fi
+
+    if [[ -n ${BB_PROMPT_CLOCK} ]]; then
+      # TODO: Move to first line of prompt :S
+      RPROMPT=$'%F{#2aa198}%D{%H:%M:%S}%f' # right clock
     fi
 }
 add-zsh-hook precmd prompt_precmd

--- a/bb.zsh
+++ b/bb.zsh
@@ -9,25 +9,15 @@
 #   https://github.com/zsh-users/zsh/blob/master/Misc/vcs_info-examples
 
 ### Defining variables
-if [[ ${TERM_PROGRAM} = "WarpTerminal" ]]; then
-  ! [ -v BB_PROMPT_DIR ] && BB_PROMPT_DIR="#6c71c4"
-  ! [ -v BB_PROMPT_GIT ] && BB_PROMPT_GIT="#586e75"
-  ! [ -v BB_PROMPT_BRANCH ] && BB_PROMPT_BRANCH="#dc322f"
-  ! [ -v BB_PROMPT_ACTION ] && BB_PROMPT_ACTION="#b58900"
-  ! [ -v BB_PROMPT_AHEAD_BEHIND ] && BB_PROMPT_AHEAD_BEHIND="#2aa198"
-  ! [ -v BB_PROMPT_TAG ] && BB_PROMPT_TAG="#93a1a1"
-  ! [ -v BB_PROMPT_COUNT ] && BB_PROMPT_COUNT="#93a1a1"
-else
-  # use ansi escape codes for terminal colors
-  # default colors picked with solarized theme
-  ! [ -v BB_PROMPT_DIR ] && BB_PROMPT_DIR="13"
-  ! [ -v BB_PROMPT_GIT ] && BB_PROMPT_GIT="10"
-  ! [ -v BB_PROMPT_BRANCH ] && BB_PROMPT_BRANCH="1"
-  ! [ -v BB_PROMPT_ACTION ] && BB_PROMPT_ACTION="3"
-  ! [ -v BB_PROMPT_AHEAD_BEHIND ] && BB_PROMPT_AHEAD_BEHIND="4"
-  ! [ -v BB_PROMPT_TAG ] && BB_PROMPT_TAG="14"
-  ! [ -v BB_PROMPT_COUNT ] && BB_PROMPT_COUNT="14"
-fi
+# use ansi escape codes for terminal colors
+# default colors picked with solarized theme
+! [ -v BB_PROMPT_DIR ] && BB_PROMPT_DIR="13"
+! [ -v BB_PROMPT_GIT ] && BB_PROMPT_GIT="10"
+! [ -v BB_PROMPT_BRANCH ] && BB_PROMPT_BRANCH="1"
+! [ -v BB_PROMPT_ACTION ] && BB_PROMPT_ACTION="3"
+! [ -v BB_PROMPT_AHEAD_BEHIND ] && BB_PROMPT_AHEAD_BEHIND="4"
+! [ -v BB_PROMPT_TAG ] && BB_PROMPT_TAG="14"
+! [ -v BB_PROMPT_COUNT ] && BB_PROMPT_COUNT="14"
 
 ! [ -v BB_PROMPT_PROJECTS_PATH ] && BB_PROMPT_PROJECTS_PATH="${HOME}/code"
 # disable checking only in the subtree of BB_PROMPT_PROJECTS_PATH

--- a/bb.zsh
+++ b/bb.zsh
@@ -98,21 +98,12 @@ warp_term_program() {
 prompt_precmd() {
     # first run the system so everything is setup correctly.
     vcs_info
+
     # Only populate PS1 with vcs_info when the vcs_info_msg'es length is not zero
     if [[ -z ${vcs_info_msg_0_} ]]; then
-        # check if zsh runs inside warp terminal
-        # handle warp prompt differently
-        if "$(warp_term_program)"; then
-            PS1="%B%F{${BB_PROMPT_DIR}}%~%f"
-        else
-            PS1=$'\n''%B%F{${BB_PROMPT_DIR}}%~%f'$'\n''%(?.%F{2}${BB_PROMPT_SIGN}.%F{9}${BB_PROMPT_SIGN})%f%b '
-        fi
+        PS1=$'\n''%B%F{${BB_PROMPT_DIR}}%~%f'$'\n''%(?.%F{2}${BB_PROMPT_SIGN}.%F{9}${BB_PROMPT_SIGN})%f%b '
     else
-        if "$(warp_term_program)"; then
-            PS1="%B%F{${BB_PROMPT_DIR}}%~%f ${vcs_info_msg_0_}%b"
-        else
-            PS1=$'\n''%B%F{${BB_PROMPT_DIR}}%~%f ${vcs_info_msg_0_}'$'\n''%(?.%F{2}${BB_PROMPT_SIGN}.%F{9}${BB_PROMPT_SIGN})%f%b '
-        fi
+        PS1=$'\n''%B%F{${BB_PROMPT_DIR}}%~%f ${vcs_info_msg_0_}'$'\n''%(?.%F{2}${BB_PROMPT_SIGN}.%F{9}${BB_PROMPT_SIGN})%f%b '
     fi
 }
 add-zsh-hook precmd prompt_precmd

--- a/bb.zsh
+++ b/bb.zsh
@@ -16,16 +16,18 @@
 ! [ -v BB_PROMPT_BRANCH ] && BB_PROMPT_BRANCH="1"
 ! [ -v BB_PROMPT_ACTION ] && BB_PROMPT_ACTION="3"
 ! [ -v BB_PROMPT_AHEAD_BEHIND ] && BB_PROMPT_AHEAD_BEHIND="4"
-! [ -v BB_PROMPT_TAG ] && BB_PROMPT_TAG="14"
 ! [ -v BB_PROMPT_COUNT ] && BB_PROMPT_COUNT="14"
+
+# The following colors are optional
+# when set the tag/clock will be enabled
+! [ -v BB_PROMPT_TAG ] && BB_PROMPT_TAG=""
+! [ -v BB_PROMPT_CLOCK ] && BB_PROMPT_CLOCK=""
 
 ! [ -v BB_PROMPT_PROJECTS_PATH ] && BB_PROMPT_PROJECTS_PATH="${HOME}/code"
 # disable checking only in the subtree of BB_PROMPT_PROJECTS_PATH
 # by setting BB_PROMPT_PROJECTS to false
 ! [ -v BB_PROMPT_PROJECTS ] && BB_PROMPT_PROJECTS=true
-! [ -v BB_PROMPT_SHOW_TAG ] && BB_PROMPT_SHOW_TAG=false
 ! [ -v BB_PROMPT_SIGN ] && BB_PROMPT_SIGN="%%"
-! [ -v BB_PROMPT_CLOCK ] && BB_PROMPT_CLOCK=""
 
 ## vim:ft=zsh
 
@@ -185,7 +187,7 @@ zstyle ':vcs_info:git*' actionformats "%F{${BB_PROMPT_GIT}}%s:(%f%F{${BB_PROMPT_
 
 ### ORDER HERE MATTERS
 
-if ${BB_PROMPT_SHOW_TAG}; then
+if [[ -n ${BB_PROMPT_TAG} ]]; then
     zstyle ':vcs_info:git*+set-message:*' hooks git-st git-count git-tag git-branch git-stash
 else
     zstyle ':vcs_info:git*+set-message:*' hooks git-st git-count git-branch git-stash


### PR DESCRIPTION
Warp update 2024.07.11 (v0.2024.07.09.08.01) enabled the possibility to have a `Same line prompt`.

This leads to the BB prompt finally being able to show its own second line with a green/red success of the last executed command.
<img width="52" alt="Screenshot 2024-07-20 at 10 00 24" src="https://github.com/user-attachments/assets/afe35163-0fa8-4893-a63c-b12751aff78f">
<img width="24" alt="Screenshot 2024-07-20 at 10 00 43" src="https://github.com/user-attachments/assets/02423ee2-e42c-4701-a5b0-749257b81b26">

Furthermore the redundant env `BB_PROMPT_SHOW_TAG` has been removed. Instead one can set a color for the git tag. If thats the case the git tag will be active and shown in the prompt.

> For reference:
> https://docs.warp.dev/getting-started/changelog#id-2024.07.11-v0.2024.07.09.08.01